### PR TITLE
Remove decl holder and decl specialisation nodes

### DIFF
--- a/include/acorn/ast/visitor.h
+++ b/include/acorn/ast/visitor.h
@@ -13,8 +13,6 @@ namespace acorn::ast {
     class TypeName;
     class DeclName;
     class ParamName;
-    class SpecialisedDecl;
-    class DeclHolder;
     class VarDecl;
     class Int;
     class Float;
@@ -60,8 +58,6 @@ namespace acorn::ast {
         virtual void visit_type_name(TypeName *node);
         virtual void visit_decl_name(DeclName *node);
         virtual void visit_param_name(ParamName *node);
-        virtual void visit_specialised_decl(SpecialisedDecl *node);
-        virtual void visit_decl_holder(DeclHolder *node);
         virtual void visit_var_decl(VarDecl *node);
         virtual void visit_int(Int *node);
         virtual void visit_float(Float *node);

--- a/include/acorn/parser/parser.h
+++ b/include/acorn/parser/parser.h
@@ -46,7 +46,6 @@ namespace acorn::parser {
         std::unique_ptr<ast::ParamName> read_param_name();
         std::unique_ptr<ast::ParamName> read_param_operator();
         std::unique_ptr<ast::VarDecl> read_var_decl();
-        std::unique_ptr<ast::DeclHolder> read_var();
         std::unique_ptr<ast::Int> read_int();
         std::unique_ptr<ast::Float> read_float();
         std::unique_ptr<ast::String> read_string();
@@ -72,11 +71,8 @@ namespace acorn::parser {
         std::unique_ptr<ast::Parameter> read_parameter();
         std::unique_ptr<ast::Let> read_let();
         std::unique_ptr<ast::DefDecl> read_def_decl();
-        std::unique_ptr<ast::DeclHolder> read_def();
         std::unique_ptr<ast::TypeDecl> read_type_decl();
-        std::unique_ptr<ast::DeclHolder> read_type();
         std::unique_ptr<ast::ModuleDecl> read_module_decl();
-        std::unique_ptr<ast::DeclHolder> read_module();
         std::unique_ptr<ast::Import> read_import_expression();
 
     private:

--- a/include/acorn/typesystem/checker.h
+++ b/include/acorn/typesystem/checker.h
@@ -54,7 +54,6 @@ namespace acorn::typesystem {
         void visit_name(ast::Name *node) override;
         void visit_type_name(ast::TypeName *node) override;
         void visit_param_name(ast::ParamName *node) override;
-        void visit_decl_holder(ast::DeclHolder *node) override;
         void visit_var_decl(ast::VarDecl *node) override;
         void visit_int(ast::Int *node) override;
         void visit_float(ast::Float *node) override;

--- a/lib/ast/visitor.cpp
+++ b/lib/ast/visitor.cpp
@@ -30,10 +30,6 @@ void Visitor::visit_node(Node *node) {
         visit_decl_name(decl_name);
     } else if (auto param_name = llvm::dyn_cast<ParamName>(node)) {
         visit_param_name(param_name);
-    } else if (auto specialised_decl = llvm::dyn_cast<SpecialisedDecl>(node)) {
-        visit_specialised_decl(specialised_decl);
-    } else if (auto decl_holder = llvm::dyn_cast<DeclHolder>(node)) {
-        visit_decl_holder(decl_holder);
     } else if (auto var_decl = llvm::dyn_cast<VarDecl>(node)) {
         visit_var_decl(var_decl);
     } else if (auto int_ = llvm::dyn_cast<Int>(node)) {
@@ -124,18 +120,6 @@ void Visitor::visit_param_name(ParamName *node) {
 
     for (auto &parameter : node->parameters()) {
         visit_node(parameter);
-    }
-}
-
-void Visitor::visit_specialised_decl(SpecialisedDecl *node) {
-    visit_node(node->declaration());
-}
-
-void Visitor::visit_decl_holder(DeclHolder *node) {
-    visit_node(node->main_instance());
-
-    for (auto &instance : node->specialised_instances()) {
-        visit_node(instance);
     }
 }
 

--- a/lib/codegen/generator.cpp
+++ b/lib/codegen/generator.cpp
@@ -739,8 +739,7 @@ void CodeGenerator::visit_assignment(ast::Assignment *node) {
     llvm::Value *rhs_value = nullptr;
 
     if (node->builtin()) {
-        auto var = static_cast<ast::VarDecl *>(node->lhs()->main_instance());
-        rhs_value = generate_builtin_variable(var);
+        rhs_value = generate_builtin_variable(node->lhs());
     } else {
         rhs_value = generate_llvm_value(node->rhs());
     }

--- a/lib/parser/parser.cpp
+++ b/lib/parser/parser.cpp
@@ -221,11 +221,11 @@ std::unique_ptr<Node> Parser::read_expression(bool parse_comma) {
     if (is_keyword("let")) {
         return read_let();
     } else if (is_keyword("def")) {
-        return read_def();
+        return read_def_decl();
     } else if (is_keyword("type")) {
-        return read_type();
+        return read_type_decl();
     } else if (is_keyword("module")) {
-        return read_module();
+        return read_module_decl();
     } else {
         auto unary_expression = read_unary_expression(parse_comma);
         return_null_if_null(unary_expression);
@@ -371,15 +371,6 @@ std::unique_ptr<VarDecl> Parser::read_var_decl() {
 
     return std::make_unique<VarDecl>(
         let_token, std::move(name), std::move(type_name), builtin
-    );
-}
-
-std::unique_ptr<DeclHolder> Parser::read_var() {
-    auto instance = read_var_decl();
-    return_null_if_null(instance);
-
-    return std::make_unique<DeclHolder>(
-        instance->token(), std::move(instance)
     );
 }
 
@@ -682,7 +673,7 @@ std::unique_ptr<If> Parser::read_if() {
     std::unique_ptr<Node> condition;
 
     if (is_keyword("let")) {
-        auto lhs = read_var();
+        auto lhs = read_var_decl();
         return_null_if_null(lhs);
 
         Token assignment_token;
@@ -930,7 +921,7 @@ std::unique_ptr<Parameter> Parser::read_parameter() {
 }
 
 std::unique_ptr<Let> Parser::read_let() {
-    auto lhs = read_var();
+    auto lhs = read_var_decl();
     return_null_if_null(lhs);
 
     std::unique_ptr<Node> rhs;
@@ -1003,13 +994,6 @@ std::unique_ptr<DefDecl> Parser::read_def_decl() {
     );
 }
 
-std::unique_ptr<DeclHolder> Parser::read_def() {
-    auto instance = read_def_decl();
-    return_null_if_null(instance);
-
-    return std::make_unique<DeclHolder>(instance->token(), std::move(instance));
-}
-
 std::unique_ptr<TypeDecl> Parser::read_type_decl() {
     Token type_token;
     return_null_if_false(read_keyword("type", type_token));
@@ -1057,13 +1041,6 @@ std::unique_ptr<TypeDecl> Parser::read_type_decl() {
     }
 }
 
-std::unique_ptr<DeclHolder> Parser::read_type() {
-    auto instance = read_type_decl();
-    return_null_if_null(instance);
-
-    return std::make_unique<DeclHolder>(instance->token(), std::move(instance));
-}
-
 std::unique_ptr<ModuleDecl> Parser::read_module_decl() {
     Token module_token;
     return_null_if_false(read_keyword("module", module_token));
@@ -1077,13 +1054,6 @@ std::unique_ptr<ModuleDecl> Parser::read_module_decl() {
     return std::make_unique<ModuleDecl>(
         module_token, std::move(name), std::move(body)
     );
-}
-
-std::unique_ptr<DeclHolder> Parser::read_module() {
-    auto instance = read_module_decl();
-    return_null_if_null(instance);
-
-    return std::make_unique<DeclHolder>(instance->token(), std::move(instance));
 }
 
 std::unique_ptr<Import> Parser::read_import_expression() {

--- a/lib/typesystem/checker.cpp
+++ b/lib/typesystem/checker.cpp
@@ -225,12 +225,6 @@ void TypeChecker::visit_param_name(ast::ParamName *node) {
     node->copy_type_from(node->name());
 }
 
-void TypeChecker::visit_decl_holder(ast::DeclHolder *node) {
-    ast::Visitor::visit_decl_holder(node);
-
-    node->copy_type_from(node->main_instance());
-}
-
 void TypeChecker::visit_var_decl(ast::VarDecl *node) {
     auto symbol = scope()->lookup(this, node->name());
 


### PR DESCRIPTION
These were going to be used for generics, but we want the AST to represent all the generic and abstract types. Only in code generation will the specialisations be created.